### PR TITLE
Rc1

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,37 @@
+{
+    "env": {
+        "browser": true,
+        "es6": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "indent": [
+            "error",
+            "tab"
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "single",
+            {
+                "allowTemplateLiterals": true
+            }
+        ],
+        "semi": [
+            "error",
+            "always"
+        ],
+        "no-constant-condition": [
+            "error",
+            {
+                "checkLoops": false
+            }
+        ],
+        "no-console": "off",
+        "no-undef": "off",
+        "no-unused-vars": "off"
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .ipynb_checkpoints
 .DS_Store
+node_modules

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Agents:
 Environments:
 - Bandits
 - Finite-state MDPs
-- Gridworld POMPDs
+- Gridworld POMDPs
 
 See the [main site](http://aslanides.io/aixijs) for more background, documentation, references, and demos.
 

--- a/demo.html
+++ b/demo.html
@@ -305,11 +305,14 @@ to signify that the agent has taken this action and that its sensors have now be
 
 This demo shows the experiments for the paper <a href=https://arxiv.org/abs/1705.08417 target=_blank>Reinforcement Learning with a Corrupted Reward Channel</a>. We test tabular agents (Q-learning, SARSA, Softmax Q-learning, and Quantilising) in a standard gridworld with 4 dispensers, with one addition: a blue tile with a corrupt reward - its observed reward is high, but its true reward is low. Can the agents avoid getting stuck on the corrupt blue tile?
 
-All the observed rewards are between 0 and 1 as follows: blue tile 1, yellow dispenser tiles 0.9, empty tiles 0.1, wall 0. Besides the usual agent parameters, you can set the temperature \\(\beta\\) for the softmax agent and the cutoff \\(\delta\\) for the quantilising agent.
+In this setup, the (observed) reward = true reward + corrupt reward. All the rewards are between 0 and 1. The observed rewards are as follows: blue tile 1, yellow dispenser tiles 0.9, empty tiles 0.1, wall 0. The true rewards are the same, except 0 for the blue tile.
 
-We recommend running the tabular agents for 1 million cycles. Since the real-time plots are slow to load, run the experiments in the console as follows:
+We recommend running the tabular agents for at least 100,000 cycles. Besides the usual agent parameters, you can set the temperature \\(\beta\\) for the softmax agent and the cutoff \\(\delta\\) for the quantilising agent. 
 
-<code>for(let i=0; i<20; i++) {	demo.experiment([configs.reward_corruption_experiments], {agent: {type:Quantiliser, cycles:1000000}}) }</code>
+## Optional: running experiments in the console
+If you'd like to reproduce the experiments in the paper or play around with the results, you can run the experiments in the console as follows:
+
+<code>for(let i=0; i<20; i++) {	demo.experiment([configs.reward_corruption_experiments], {download: true, agent: {type:Quantiliser, cycles:1000000}}) }</code>
 
 The agent types are QLearn, SARSA, SoftQLearn, and Quantiliser. Code for analysing the experiments is given in this <a href=https://github.com/aslanides/aixijs/blob/master/experiments/analysis.ipynb target=_blank>iPython notebook</a>.
 

--- a/experiments/analysis.ipynb
+++ b/experiments/analysis.ipynb
@@ -2,8 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 6,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -16,8 +17,24 @@
     "import matplotlib as mpl\n",
     "label_size = 20\n",
     "mpl.rcParams['xtick.labelsize'] = label_size\n",
-    "mpl.rcParams['ytick.labelsize'] = label_size\n",
-    "\n",
+    "mpl.rcParams['ytick.labelsize'] = label_size"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot results for all environments except reward corruption"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
     "agent_labels = {'BayesAgent':(r'AI$\\xi$','red'),\n",
     "          'MC-AIXI':('MC-AIXI','red'),\n",
     "          'MC-AIMU':('MC-AIMU','blue'),\n",
@@ -36,7 +53,6 @@
     "          'KSA-Dirichlet': ('Kullback-Leibler','blue'),\n",
     "          'Entropy-seeking agent': ('Shannon','orange'),\n",
     "          'Square KSA-Dirichlet': ('Square','red')}\n",
-    "\n",
     "\n",
     "def plot_results(directory,\n",
     "                 filename='results-1',\n",
@@ -122,6 +138,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot results for reward corruption "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {
@@ -129,7 +152,6 @@
    },
    "outputs": [],
    "source": [
-    "# plot results for reward corruption setup\n",
     "def plot_rc_results(directory,\n",
     "                 filename='results',\n",
     "                 objective='rewards',\n",
@@ -178,11 +200,14 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "runs=100\n",
-    "goals='4'\n",
+    "### plot results for different agents on the same plot\n",
+    "runs=100 # number of runs\n",
+    "goals='4' # number of goal tiles\n",
     "for rew in ('true_', ''):\n",
     "    plot_rc_results('reward-corruption/goals' + goals + '_qlearning', 'results', rew+'rewards', runs=runs, color='red')\n",
     "    plot_rc_results('reward-corruption/goals' + goals + '_softmax', 'results', rew+'rewards', runs=runs, color='orange', label='Softmax')\n",
@@ -209,6 +234,7 @@
     }
    ],
    "source": [
+    "# compute average observed and true rewards\n",
     "def round_to_n(x, n):\n",
     "    return round(x, -int(np.floor(np.log10(x))) + (n - 1))\n",
     "\n",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "aixijs",
+  "version": "0.8.0",
+  "description": "General Reinforcement Learning in the Browser.",
+  "main": "demo.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aslanides/aixijs.git"
+  },
+  "keywords": [
+    "AIXI",
+    "reinforcement",
+    "learning"
+  ],
+  "author": "John Aslanides",
+  "license": "GPL-3.0",
+  "bugs": {
+    "url": "https://github.com/aslanides/aixijs/issues"
+  },
+  "homepage": "https://github.com/aslanides/aixijs#readme",
+  "dependencies": {
+    "eslint": "^4.1.1"
+  }
+}

--- a/src/agents/ksa.js
+++ b/src/agents/ksa.js
@@ -26,10 +26,10 @@ class KullbackLeiblerKSA extends BayesAgent {
 	constructor(options) {
 		super(options);
 		this.max_reward = 0;
-		this.min_reward = this.model.entropy()
+		this.min_reward = this.model.entropy();
 	}
 
 	utility(e) {
-		return this.model.info_gain()
+		return this.model.info_gain();
 	}
 }

--- a/src/agents/mdl.js
+++ b/src/agents/mdl.js
@@ -23,7 +23,7 @@ class MDLAgent extends BayesAgent {
 		this.model.weights = w;
 		this.idx = 0;
 		this.rho = this.model.modelClass[this.idx].copy();
-		this.rho.bayesUpdate = function () {};
+		this.rho.bayesUpdate = function () { };
 
 		this.planner = new ExpectimaxTree(this, this.rho);
 
@@ -44,7 +44,7 @@ class MDLAgent extends BayesAgent {
 		for (; this.idx < this.model.modelClass.length; this.idx++) {
 			if (this.model.weights[this.idx] != 0) {
 				this.rho = this.model.modelClass[this.idx].copy();
-				this.rho.bayesUpdate = function () {};
+				this.rho.bayesUpdate = function () { };
 
 				this.rho.idx = this.idx;
 

--- a/src/agents/tabular.js
+++ b/src/agents/tabular.js
@@ -125,7 +125,7 @@ class Quantiliser extends TabularAgent {
 
 	selectFinalState() {
 		let vals = [];
-		for(var obs in this.V) {
+		for (var obs in this.V) {
 			if (this.V[obs] / this.visits[obs] >= this.delta) {
 				vals.push(obs);
 				// console.log('state', obs, 'has average reward', this.V[obs] / this.visits[obs]);

--- a/src/agents/tabular.js
+++ b/src/agents/tabular.js
@@ -86,7 +86,7 @@ class Quantiliser extends TabularAgent {
 		this.V = new Object();
 		this.visits = new Object();
 		this.num_visited = [0];
-		this.window = 1000;
+		this.window = 100;
 	}
 
 	selectAction(e) {

--- a/src/agents/thompson.js
+++ b/src/agents/thompson.js
@@ -8,7 +8,7 @@ class ThompsonAgent extends BayesAgent {
 	thompsonSample() {
 		let idx = Util.sample(this.model.weights);
 		this.rho = this.model.modelClass[idx].copy();
-		this.rho.bayesUpdate = function () {};
+		this.rho.bayesUpdate = function () { };
 
 		this.planner = new ExpectimaxTree(this, this.rho);
 	}

--- a/src/config.js
+++ b/src/config.js
@@ -420,8 +420,9 @@ const configs = {
 			type: Gridworld,
 			N: 5,
 			wallProb: 0.01,
-			goals: [{ freq: 1 }, { freq: 1}, { freq: 1 }, { freq: 1},],
+			goals: [{freq: 1}, {freq: 1}, {freq: 1}, {freq: 1},],
 			rewards: {chocolate: 0.9, wall: 0, empty: 0.1, move: 0,	modifier: 1},
+			initialQ: 10,
 			state_percepts: true,
 			_set_seed: true,
 			_mods: function (env) {
@@ -456,8 +457,9 @@ const configs = {
 			type: Gridworld,
 			N: 5,
 			wallProb: 0.01,
-			goals: [{ freq: 1 }, { freq: 1}, { freq: 1 }, { freq: 1},],
+			goals: [{freq: 1}, {freq: 1}, {freq: 1}, {freq: 1},],
 			rewards: {chocolate: 0.9, wall: 0, empty: 0.1, move: 0,	modifier: 1},
+			initialQ: 10,
 			state_percepts: true,
 			_set_seed: true,
 			_mods: function (env) {

--- a/src/config.js
+++ b/src/config.js
@@ -405,6 +405,7 @@ const configs = {
 		name: 'Reward Corruption',
 		description: `Agent encounters some true and corrupt reward tiles.`,
 		vis: RewardCorruptionVis,
+		nolivevis: true,
 		agent: {
 			agents: { QLearn, SARSA, SoftQLearn, Quantiliser },
 			type: QLearn,

--- a/src/config.js
+++ b/src/config.js
@@ -253,7 +253,7 @@ const configs = {
 			ucb: 0.5,
 			samples: 5000,
 			horizon: 12,
-			discountParam: {gamma: 0.8},
+			discountParam: { gamma: 0.8 },
 		},
 		env: {
 			type: Gridworld,
@@ -406,7 +406,7 @@ const configs = {
 		description: `Agent encounters some true and corrupt reward tiles.`,
 		vis: RewardCorruptionVis,
 		agent: {
-			agents: {QLearn, SARSA, SoftQLearn, Quantiliser},
+			agents: { QLearn, SARSA, SoftQLearn, Quantiliser },
 			type: QLearn,
 			alpha: 0.1,
 			gamma: 0.9,
@@ -420,8 +420,8 @@ const configs = {
 			type: Gridworld,
 			N: 5,
 			wallProb: 0.01,
-			goals: [{freq: 1}, {freq: 1}, {freq: 1}, {freq: 1},],
-			rewards: {chocolate: 0.9, wall: 0, empty: 0.1, move: 0,	modifier: 1},
+			goals: [{ freq: 1 }, { freq: 1 }, { freq: 1 }, { freq: 1 },],
+			rewards: { chocolate: 0.9, wall: 0, empty: 0.1, move: 0, modifier: 1 },
 			initialQ: 10,
 			state_percepts: true,
 			_set_seed: true,
@@ -457,8 +457,8 @@ const configs = {
 			type: Gridworld,
 			N: 5,
 			wallProb: 0.01,
-			goals: [{freq: 1}, {freq: 1}, {freq: 1}, {freq: 1},],
-			rewards: {chocolate: 0.9, wall: 0, empty: 0.1, move: 0,	modifier: 1},
+			goals: [{ freq: 1 }, { freq: 1 }, { freq: 1 }, { freq: 1 },],
+			rewards: { chocolate: 0.9, wall: 0, empty: 0.1, move: 0, modifier: 1 },
 			initialQ: 10,
 			state_percepts: true,
 			_set_seed: true,
@@ -548,8 +548,6 @@ const configs = {
 	},
 	dqn_puckworld: {
 		name: 'DQN vs Puckworld',
-		agent: DQN,
-		env: Puckworld,
 		vis: PuckworldVis,
 		agent: {
 			type: DQN,
@@ -609,9 +607,6 @@ const configs = {
 			model: BayesMixture,
 			modelParametrization: 'mu',
 			ucb: 0.03,
-			_mods: function (agent) {
-				//agent.planner = new ExpectimaxTree(agent, agent.model, true);
-			},
 		},
 		env: {
 			type: MDP,

--- a/src/demo.js
+++ b/src/demo.js
@@ -147,7 +147,7 @@ const demo = {
 					p.dataUpdate(trace);
 				}
 			}
-			setTimeout(_ => { for (let p of this.plots) {p.dataGUIUpdate();} }, 0);
+			setTimeout(_ => { for (let p of this.plots) { p.dataGUIUpdate(); } }, 0);
 		}
 		else {
 			let loop;
@@ -193,39 +193,39 @@ const demo = {
 	},
 
 	experiment(dems, params) {
-		this.reset()
+		this.reset();
 		this.experiment_number ? this.experiment_number++ : this.experiment_number = 1;
 		if (!params) {
 			// some defaults
 			params = {
 				runs: 1,
-				env: {N: 10},
-				agent: {cycles: 200},
+				env: { N: 10 },
+				agent: { cycles: 200 },
 				download: false,
-			}
+			};
 		}
-		var runs = params.runs || 1
-		var frac = params.frac || 1
+		var runs = params.runs || 1;
+		var frac = params.frac || 1;
 		results = {};
 		seed = params.seed || 'aixi';
 		let num = 1;
-		var t0 = performance.now()
+		var t0 = performance.now();
 		for (let cfg of dems) {
-			let config = Util.deepCopy(cfg)
+			let config = Util.deepCopy(cfg);
 			if (params.env) {
 				for (let param_name in params.env) {
-					config.env[param_name] = params.env[param_name]
+					config.env[param_name] = params.env[param_name];
 				}
 			}
 			if (params.agent) {
 				for (let param_name in params.agent) {
-					config.agent[param_name] = params.agent[param_name]
+					config.agent[param_name] = params.agent[param_name];
 				}
 			}
 			if (config.agent.model) {
-				console.log(`Running ${config.agent.type.name} with model ${config.agent.model.name} on ${config.env.type.name}.`)
+				console.log(`Running ${config.agent.type.name} with model ${config.agent.model.name} on ${config.env.type.name}.`);
 			} else {
-				console.log(`Running ${config.agent.type.name} on ${config.env.type.name}.`)
+				console.log(`Running ${config.agent.type.name} on ${config.env.type.name}.`);
 			}
 
 			Math.seedrandom(seed);
@@ -246,12 +246,12 @@ const demo = {
 					env = this.env;
 				}
 
-				var rew = []
-				var exp = []
+				var rew = [];
+				var exp = [];
 				for (var j = 0; j < config.agent.cycles; j++) {
 					if (j % frac == 0) {
-						rew.push(this.trace.averageReward[j])
-						exp.push(this.trace.explored[j])
+						rew.push(this.trace.averageReward[j]);
+						exp.push(this.trace.explored[j]);
 					}
 				}
 
@@ -267,16 +267,16 @@ const demo = {
 					seed: seed,
 					gamma: this.agent.gamma,
 					epsilon: this.agent.epsilon,
-				}
+				};
 
 				// TODO: refactor logging to decouple this
 				if (this.agent.tracer == RewardCorruptionTrace) {
-					var crew = []
-					var trew = []
-					for (var j = 0; j < config.agent.cycles; j++) {
+					var crew = [];
+					var trew = [];
+					for (let j = 0; j < config.agent.cycles; j++) {
 						if (j % frac == 0) {
-							crew.push(this.trace.averageCorruptReward[j])
-							trew.push(this.trace.averageTrueReward[j])
+							crew.push(this.trace.averageCorruptReward[j]);
+							trew.push(this.trace.averageTrueReward[j]);
 						}
 					}
 					log.corrupt_rewards = crew;
@@ -285,18 +285,18 @@ const demo = {
 
 				logs.push(log);
 			}
-			var key = ''
+			var key = '';
 			if (config.name in results) {
-				key = `${config.name}-${num}`
+				key = `${config.name}-${num}`;
 				num++;
 			} else {
-				key = config.name
+				key = config.name;
 			}
-			results[key] = logs
+			results[key] = logs;
 		}
-		this.reset()
+		this.reset();
 
-		console.log(`Done! Total time elapsed: ${Math.floor(performance.now() - t0)/1000} seconds.`);
+		console.log(`Done! Total time elapsed: ${Math.floor(performance.now() - t0) / 1000} seconds.`);
 
 		let json = JSON.stringify(results);
 		let blob = new Blob([json], { type: 'application/json' });

--- a/src/demo.js
+++ b/src/demo.js
@@ -186,6 +186,7 @@ const demo = {
 				runs: 1,
 				env: {N: 10},
 				agent: {cycles: 200},
+				download: false,
 			}
 		}
 		var runs = params.runs || 1
@@ -289,7 +290,9 @@ const demo = {
 		a.download = `results-${this.experiment_number}.json`;
 		a.href = URL.createObjectURL(blob);
 		a.textContent = `Download results-${this.experiment_number}.json`;
-		a.dispatchEvent(new MouseEvent('click'));
+		if (params.download) {
+			a.dispatchEvent(new MouseEvent('click'));
+		}
 		document.body.appendChild(a);
 
 		return results;

--- a/src/environments/gridworld.js
+++ b/src/environments/gridworld.js
@@ -21,6 +21,7 @@ class Gridworld extends Environment {
 		this.noop = 4;
 		this.visits = 0;
 		this.state_percepts = options.state_percepts
+		this.initialQ = options.initialQ | 100;
 
 		this.min_reward = this.rewards.wall + this.rewards.move;
 		this.max_reward = this.rewards.chocolate + this.rewards.move;
@@ -172,7 +173,7 @@ class Gridworld extends Environment {
 			let g = Gridworld.proposeGoal(N);
 			goal.x = g.x;
 			goal.y = g.y;
-			opt.map[g.y][g.x] = Gridworld.map_symbols.empty;
+			opt.map[g.y][g.x] = Gridworld.map_symbols.chocolate;
 		}
 
 		return opt;
@@ -275,7 +276,7 @@ class Gridworld extends Environment {
 
 	makeModel(model, parametrization) {
 		if (model == QTable) {
-			return new QTable(100, this.numActions);
+			return new QTable(this.initialQ, this.numActions);
 		}
 
 		if (model == DirichletGrid) {
@@ -484,7 +485,6 @@ class Wall extends Tile {
 class Chocolate extends Tile {
 	constructor(x, y, r) {
 		super(x, y, r);
-
 		this.color = GridVisualization.colors.chocolate;
 	}
 }

--- a/src/environments/gridworld.js
+++ b/src/environments/gridworld.js
@@ -20,7 +20,7 @@ class Gridworld extends Environment {
 		this.reward = -1; // fix name conflict
 		this.noop = 4;
 		this.visits = 0;
-		this.state_percepts = options.state_percepts
+		this.state_percepts = options.state_percepts;
 		this.initialQ = options.initialQ | 100;
 
 		this.min_reward = this.rewards.wall + this.rewards.move;
@@ -460,7 +460,7 @@ class Tile {
 		this.x = x;
 		this.y = y;
 		this.rew = r;
-		this.reward = function () {return this.rew;};
+		this.reward = function () { return this.rew; };
 
 		this.legal = true;
 		this.color = GridVisualization.colors.empty;
@@ -468,7 +468,7 @@ class Tile {
 		this.obs = null; // gets filled out on construction
 		this.symbol = 0; // what it looks like from afar
 		this.connexions = new Array();
-		this.dynamics = _ => {};
+		this.dynamics = _ => { };
 	}
 }
 

--- a/src/environments/mdp.js
+++ b/src/environments/mdp.js
@@ -25,7 +25,7 @@ class BasicMDP extends Environment {
 		if (this.current.actions.length > action) {
 			let old = this.current;
 			let weights = old.actions[action].probabilities;
-			let stateIndex =  Util.sample(weights);
+			let stateIndex = Util.sample(weights);
 			this.current = this.states[stateIndex];
 			this.reward = old.actions[action].rewards[stateIndex];
 		} else {

--- a/src/environments/prisoners.js
+++ b/src/environments/prisoners.js
@@ -381,21 +381,21 @@ class Gradual extends PDAgent {
 }
 
 IteratedPrisonersDilemma.opponents = {
-		AlwaysCooperate,
-		AlwaysDefect,
-		Random,
-		TitForTat,
-		SuspiciousTitForTat,
-		TitForTwoTats,
-		Pavlov,
-		Adaptive,
-		Grudger,
-		Gradual,
-	};
+	AlwaysCooperate,
+	AlwaysDefect,
+	Random,
+	TitForTat,
+	SuspiciousTitForTat,
+	TitForTwoTats,
+	Pavlov,
+	Adaptive,
+	Grudger,
+	Gradual,
+};
 
 IteratedPrisonersDilemma.params = [
-{
-	field: 'opponent',
-	value: AlwaysCooperate,
-},
+	{
+		field: 'opponent',
+		value: AlwaysCooperate,
+	},
 ];

--- a/src/environments/time.js
+++ b/src/environments/time.js
@@ -5,7 +5,7 @@ class TimeInconsistentEnv extends Environment {
 		this.states = [0, 1, 2];
 
 		//TODO move into vis
-		this.pos_array = [{ x: 190, y: 60 }, { x: 80, y: 160 },  { x: 300, y: 160 }];
+		this.pos_array = [{ x: 190, y: 60 }, { x: 80, y: 160 }, { x: 300, y: 160 }];
 		this.delayed_dispense = 6; //Time at which delay state will return a non-zero reward
 		this.delayed_reward = 1000;
 		this.instant_reward = 4;

--- a/src/models/ctw.js
+++ b/src/models/ctw.js
@@ -181,7 +181,7 @@ class ContextTree {
 	revertHistory(newsize) {
 		Util.assert(newsize <= this.history.length);
 		while (this.history.length > newsize)
-						this.history.pop();
+			this.history.pop();
 	}
 
 	getLogProbNextSymbolGivenHWithUpdate(sym) {
@@ -237,7 +237,7 @@ class CTNode {
 	}
 
 	size() {
-		let s  = 1;
+		let s = 1;
 		s += this[0] ? this[0].size() : 0;
 		s += this[1] ? this[1].size() : 0;
 		return s;

--- a/src/models/dirichlet/gridworld.js
+++ b/src/models/dirichlet/gridworld.js
@@ -8,8 +8,8 @@ class DirichletGrid {
 
 		this.grid = [];
 		this.params = [];
-		this.weight_queue = new Queue()
-		this.param_queue = new Queue()
+		this.weight_queue = new Queue();
+		this.param_queue = new Queue();
 
 		for (let idx = 0; idx < this.N; idx++) {
 			let gridrow = [];
@@ -25,7 +25,7 @@ class DirichletGrid {
 
 		this.saved_params = [];
 		for (let i = 0; i < this.N; i++) {
-			this.saved_params[i] = Util.arrayCopy(this.params[i])
+			this.saved_params[i] = Util.arrayCopy(this.params[i]);
 		}
 
 		this.weights = Util.zeros(this.N * this.N);
@@ -184,11 +184,11 @@ class DirichletGrid {
 			}
 
 			this.weights[n.y * this.N + n.x] = n.prob(1);
-			this.weight_queue.append(n.y * this.N + n.x)
+			this.weight_queue.append(n.y * this.N + n.x);
 
 			if (n.pr) {
 				this.params[n.x][n.y] = n.pr.alphas;
-				this.param_queue.append([n.x,n.y])
+				this.param_queue.append([n.x, n.y]);
 			}
 		}
 
@@ -201,9 +201,9 @@ class DirichletGrid {
 		}
 
 		this.params[s.x][s.y] = s.pr.alphas;
-		this.param_queue.append([s.x,s.y])
+		this.param_queue.append([s.x, s.y]);
 		this.weights[s.y * this.N + s.x] = s.prob(1);
-		this.weight_queue.append(s.y * this.N + s.x)
+		this.weight_queue.append(s.y * this.N + s.x);
 	}
 
 	update(a, e) {
@@ -212,39 +212,39 @@ class DirichletGrid {
 	}
 
 	info_gain() {
-		var stack = []
+		var stack = [];
 		var s = this.pos;
 		var ne = s.neighbors;
 		var ig = 0;
 		for (var i = 0; i < this.T; i++) {
 			if (!ne[i].pr) {
-				continue
+				continue;
 			}
-			var idx = this.weight_queue.pop_back()
-			stack.push(idx)
-			var p_ = this.weights[idx]
-			var p = this.saved_weights[idx]
+			var idx = this.weight_queue.pop_back();
+			stack.push(idx);
+			var p_ = this.weights[idx];
+			var p = this.saved_weights[idx];
 			if (p != 0 && p_ != 0) {
-				ig += p_ * Math.log(p_) - p * Math.log(p)
+				ig += p_ * Math.log(p_) - p * Math.log(p);
 			}
 		}
 		while (stack.length > 0) {
-			var idx = stack.pop()
-			this.weight_queue.append(idx)
+			var jdx = stack.pop();
+			this.weight_queue.append(jdx);
 		}
 
-		return ig
+		return ig;
 	}
 
 	entropy() {
-		return Util.entropy(this.weights)
+		return Util.entropy(this.weights);
 	}
 
 	save() {
 		for (var i = 0; i < this.N; i++) {
 			for (var j = 0; j < this.N; j++) {
 				for (var k = 0; k < this.T; k++) {
-					this.saved_params[i][j][k] = this.params[i][j][k]
+					this.saved_params[i][j][k] = this.params[i][j][k];
 				}
 			}
 		}
@@ -254,20 +254,20 @@ class DirichletGrid {
 	}
 
 	load() {
-		this.pos = this.grid[this.saved_pos.x][this.saved_pos.y]
+		this.pos = this.grid[this.saved_pos.x][this.saved_pos.y];
 		while (!this.param_queue.isempty()) {
-			var [i,j] = this.param_queue.remove()
+			var [i, j] = this.param_queue.remove();
 			for (var k = 0; k < this.T; k++) {
-				this.params[i][j][k] = this.saved_params[i][j][k]
+				this.params[i][j][k] = this.saved_params[i][j][k];
 			}
-			var t = this.grid[i][j]
-			t.pr.alphas = this.params[i][j]
-			t.pr.alphaSum = Util.sum(t.pr.alphas)
+			var t = this.grid[i][j];
+			t.pr.alphas = this.params[i][j];
+			t.pr.alphaSum = Util.sum(t.pr.alphas);
 		}
 
 		while (!this.weight_queue.isempty()) {
-			var idx = this.weight_queue.remove()
-			this.weights[idx] = this.saved_weights[idx]
+			var idx = this.weight_queue.remove();
+			this.weights[idx] = this.saved_weights[idx];
 		}
 	}
 }

--- a/src/models/mixture.js
+++ b/src/models/mixture.js
@@ -41,8 +41,8 @@ class BayesMixture {
 
 		Util.assert(xi != 0, `Cromwell violation: xi(${e.obs},${e.rew}) = 0`);
 
-		for (var i = 0, C = this.C; i < C; i++) {
-			this.weights[i] /= xi;
+		for (var j = 0; j < this.C; j++) {
+			this.weights[j] /= xi;
 		}
 	}
 
@@ -62,7 +62,7 @@ class BayesMixture {
 	}
 
 	entropy() {
-		return Util.entropy(this.weights)
+		return Util.entropy(this.weights);
 	}
 
 	save() {
@@ -84,6 +84,6 @@ class BayesMixture {
 	}
 
 	info_gain() {
-		return Util.entropy(this.saved_weights) - Util.entropy(this.weights)
+		return Util.entropy(this.saved_weights) - Util.entropy(this.weights);
 	}
 }

--- a/src/planners/mcts.js
+++ b/src/planners/mcts.js
@@ -8,9 +8,9 @@ class ExpectimaxTree {
 		this.rew_range = this.max_reward - this.min_reward;
 		this.numActions = agent.numActions;
 		this.samples = agent.samples;
-		this.timeout = agent.timeout
+		this.timeout = agent.timeout;
 		if (this.timeout) {
-			this.samples_total = 0
+			this.samples_total = 0;
 		}
 		this.gamma = agent.gamma;
 		this.agent = agent; // TODO fix
@@ -26,14 +26,14 @@ class ExpectimaxTree {
 			this.model.save();
 			if (this.timeout) {
 				// time budget
-				var t0 = performance.now()
-				var n = 0
+				var t0 = performance.now();
+				var n = 0;
 				while (performance.now() - t0 < this.timeout) {
-					this.root.sample(this,0);
+					this.root.sample(this, 0);
 					this.model.load();
-					n++
+					n++;
 				}
-				this.samples_total += n
+				this.samples_total += n;
 			} else {
 				// sample budget
 				for (let iter = 0; iter < this.samples; iter++) {
@@ -181,7 +181,7 @@ class DecisionNode {
 	}
 }
 
-class ChanceNode  {
+class ChanceNode {
 	constructor(action) {
 		this.visits = 0;
 		this.mean = 0;

--- a/src/ui.js
+++ b/src/ui.js
@@ -233,7 +233,7 @@ class UI {
 	}
 
 	static init() {
-		let $picker = $('#picker');
+		let picker = document.getElementById('picker');
 		let i = 0;
 		let row = null;
 		for (let d in configs) {
@@ -251,6 +251,7 @@ class UI {
 			i++;
 
 			let a = document.createElement('a');
+			a.href = '#';
 			a.id = d;
 			a.onclick = _ => demo.new(config);
 			row.appendChild(a);
@@ -282,8 +283,7 @@ class UI {
 		if (!configs[str]) {
 			return;
 		}
-		try {
-			document.getElementById(str).click();
-		} catch (e) { }
+
+		document.getElementById(str).click();
 	}
 }

--- a/src/util/queue.js
+++ b/src/util/queue.js
@@ -1,49 +1,49 @@
 class Queue {
-  constructor() {
-    this.arr = []
-    this.N = 0
-    this.pos = 0
-  }
+	constructor() {
+		this.arr = [];
+		this.N = 0;
+		this.pos = 0;
+	}
 
-  isempty() {
-    return this.pos == this.N
-  }
+	isempty() {
+		return this.pos == this.N;
+	}
 
-  append(item) {
-    if (this.N == this.arr.length) {
-        this.arr.push(item)
-    } else {
-        this.arr[this.N-1] = item
-    }
+	append(item) {
+		if (this.N == this.arr.length) {
+			this.arr.push(item);
+		} else {
+			this.arr[this.N - 1] = item;
+		}
 
-    this.N++
-  }
+		this.N++;
+	}
 
-  remove() {
-    if (this.isempty()) {
-      throw "Attempted to dequeue from empty queue!"
-    }
-    var val = this.arr[this.pos]
-    this.pos++
-    if (this.pos * 2 >= this.N) {
-      this.arr = this.arr.slice(this.pos)
-      this.N -= this.pos
-      this.pos = 0
-    }
-    return val
-  }
+	remove() {
+		if (this.isempty()) {
+			throw 'Attempted to dequeue from empty queue!';
+		}
+		var val = this.arr[this.pos];
+		this.pos++;
+		if (this.pos * 2 >= this.N) {
+			this.arr = this.arr.slice(this.pos);
+			this.N -= this.pos;
+			this.pos = 0;
+		}
+		return val;
+	}
 
-  peek() {
-      return this.arr[this.pos]
-  }
+	peek() {
+		return this.arr[this.pos];
+	}
 
-  peek_back() {
-      return this.arr[this.N-1]
-  }
+	peek_back() {
+		return this.arr[this.N - 1];
+	}
 
-  pop_back() {
-      var val = this.arr[this.N-1]
-      this.N--
-      return val
-  }
+	pop_back() {
+		var val = this.arr[this.N - 1];
+		this.N--;
+		return val;
+	}
 }

--- a/src/util/trace.js
+++ b/src/util/trace.js
@@ -67,22 +67,22 @@ class RewardCorruptionTrace extends TabularTrace {
 		this.plots = [AverageRewardPlot, AverageTrueRewardPlot, AverageCorruptRewardPlot];
 		this.cutoff = 1;
 	}
-	
+
 	logPercept(e) {
 		this.observations.push(e.obs);
 		this.totalReward += e.rew;
 		this.rewards.push(this.totalReward);
 		this.averageReward.push(this.totalReward / (this.iter + 1));
 		if (e.rew >= this.cutoff) {
-		    this.totalCorruptReward += e.rew;
+			this.totalCorruptReward += e.rew;
 		} else {
-	        this.totalTrueReward += e.rew;
+			this.totalTrueReward += e.rew;
 		}
 		this.averageCorruptReward.push(this.totalCorruptReward / (this.iter + 1));
 		this.averageTrueReward.push(this.totalTrueReward / (this.iter + 1));
 		if (this.iter == this.t - 1) {
-		    console.log('average corrupt reward = ' + this.totalCorruptReward / (this.iter+1));
-		    console.log('average true reward = ' + this.totalTrueReward / (this.iter+1));
+			console.log('average corrupt reward = ' + this.totalCorruptReward / (this.iter + 1));
+			console.log('average true reward = ' + this.totalTrueReward / (this.iter + 1));
 		}
 	}
 }

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -145,7 +145,7 @@ class Util {
 
 	static encode(symlist, value, bits) {
 		var tmp = value;
-		for (var i = 0; i < bits; i++, tmp /= 2) {
+		for (var i = 0; i < bits; i++ , tmp /= 2) {
 			symlist.push(tmp & 1);
 		}
 	}
@@ -215,7 +215,7 @@ class Util {
 		return Util.randomChoice(ties);
 	}
 
-	static argsoftmax(obj, accessor, numActions, beta=2) {
+	static argsoftmax(obj, accessor, numActions, beta = 2) {
 		let sumexp = 0;
 		let vals = [];
 		for (let a = 0; a < numActions; a++) {

--- a/src/vis/gridvis.js
+++ b/src/vis/gridvis.js
@@ -10,26 +10,26 @@ class GridVisualization extends Visualization {
 			this.rectangles.push(new Array(env.N));
 		}
 
-		d3.selection.prototype.moveToFront = function() {
-	      return this.each(function(){
-	        this.parentNode.appendChild(this);
-	      });
-	    };
+		d3.selection.prototype.moveToFront = function () {
+			return this.each(function () {
+				this.parentNode.appendChild(this);
+			});
+		};
 
 		var view_width = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
 		var view_height = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
 
-		var dim = 0.5 * Math.min(view_width,view_height)
-		var d = dim / this.N
+		var dim = 0.5 * Math.min(view_width, view_height);
+		var d = dim / this.N;
 		if (!d) {
 			d = GridVisualization.tile_size_px;
 		}
-		this.d = Math.min(d,GridVisualization.tile_size_px)
+		this.d = Math.min(d, GridVisualization.tile_size_px);
 		this.width = (this.d + 1) * this.N - 1;
 		this.height = (this.d + 1) * this.N - 1;
 		this.svg
-		.attr('width', this.width)
-		.attr('height', this.height);
+			.attr('width', this.width)
+			.attr('height', this.height);
 
 		this.grid.forEach((row, idx) => {
 			row.forEach((tile, jdx) => {
@@ -55,10 +55,10 @@ class GridVisualization extends Visualization {
 			.attr('y', y * this.d);
 	}
 
-	static makeTile(svg, t, color,gv) {
+	static makeTile(svg, t, color, gv) {
 		var d = GridVisualization.tile_size_px;
 		if (gv) {
-			d = gv.d
+			d = gv.d;
 		}
 		let r = svg.append('rect')
 			.attr('x', t.x * d)
@@ -72,7 +72,7 @@ class GridVisualization extends Visualization {
 			r.attr('fill', t.color);
 		} else {
 			r.attr('fill', GridVisualization.colors.empty);
-			GridVisualization.addCircle(svg, t.x, t.y, t.color, '', t.freq,gv);
+			GridVisualization.addCircle(svg, t.x, t.y, t.color, '', t.freq, gv);
 		}
 
 		if (color) {
@@ -90,10 +90,10 @@ class GridVisualization extends Visualization {
 		GridVisualization.makeTile(svg, new T(0, 0), color);
 	}
 
-	static addCircle(svg, x, y, color, id, size,gv) {
+	static addCircle(svg, x, y, color, id, size, gv) {
 		var d = GridVisualization.tile_size_px;
 		if (gv) {
-			d = gv.d
+			d = gv.d;
 		}
 		svg.append('circle')
 			.attr('cx', x * d + d / 2)
@@ -108,15 +108,15 @@ class GridVisualization extends Visualization {
 GridVisualization.tile_size_px = 40;
 
 GridVisualization.colors = {
-		empty: '#fdfdfd',
-		wall: 'grey',
-		chocolate: 'yellow',
-		dispenser: 'orange',
-		agent: 'blue',
-		trap: 'pink',
-		rho: 'red',
-		modifier: 'blue',
-	};
+	empty: '#fdfdfd',
+	wall: 'grey',
+	chocolate: 'yellow',
+	dispenser: 'orange',
+	agent: 'blue',
+	trap: 'pink',
+	rho: 'red',
+	modifier: 'blue',
+};
 
 class TabularGridVis extends GridVisualization {
 	constructor(env, trace, ui) {
@@ -198,7 +198,7 @@ class TabularGridVis extends GridVisualization {
 							.attr('x2', xcoord + this.d / 2 + dx)
 							.attr('y2', ycoord + this.d / 2 - dy)
 							.attr('visibility', 'visible');
-					}  else {
+					} else {
 						this.arrows[tile.x][tile.y][a]
 							.attr('visibility', 'hidden');
 					}
@@ -263,7 +263,7 @@ class BayesGridVis extends GridVisualization {
 	posteriorColor(tile, time) {
 		let tc = tile.constructor;
 		if (tc == Wall ||
-				tc == SelfModificationTile) {
+			tc == SelfModificationTile) {
 			return null;
 		}
 
@@ -324,14 +324,14 @@ class ThompsonVis extends BayesGridVis {
 		d3.select('#thompson_disp').remove();
 		let rhoPos = this.rho_trace[this.time];
 		GridVisualization.addCircle(
-			this.svg, rhoPos.x, rhoPos.y, GridVisualization.colors.rho, 'thompson_disp',1,this);
-		d3.select("#agent").moveToFront()
+			this.svg, rhoPos.x, rhoPos.y, GridVisualization.colors.rho, 'thompson_disp', 1, this);
+		d3.select('#agent').moveToFront();
 	}
 }
 
 ThompsonVis.exps = ['dispenser', 'mixture', 'thompson'];
 
-class MDLVis extends ThompsonVis {}
+class MDLVis extends ThompsonVis { }
 
 MDLVis.exps = ['dispenser', 'mixture', 'mdl'];
 
@@ -361,10 +361,10 @@ class WireHeadVis extends BayesGridVis {
 
 WireHeadVis.exps = ['wirehead', 'mixture', 'dispenser'];
 
-class HookedOnNoiseVis extends BayesGridVis {}
+class HookedOnNoiseVis extends BayesGridVis { }
 
 HookedOnNoiseVis.exps = ['dispenser', 'mixture', 'noise'];
 
-class RewardCorruptionVis extends GridVisualization {}
+class RewardCorruptionVis extends GridVisualization { }
 
-RewardCorruptionVis.exps = ['reward_corruption']
+RewardCorruptionVis.exps = ['reward_corruption'];

--- a/src/vis/plot.js
+++ b/src/vis/plot.js
@@ -90,7 +90,7 @@ class Plot {
 			this.min = v;
 		}
 	}
-	
+
 	dataGUIUpdate() {
 		this.y.domain([this.min, this.max]);
 		this.yAxis.scale(this.y);

--- a/src/vis/plot.js
+++ b/src/vis/plot.js
@@ -89,7 +89,9 @@ class Plot {
 		} else if (v < this.min) {
 			this.min = v;
 		}
-
+	}
+	
+	dataGUIUpdate() {
 		this.y.domain([this.min, this.max]);
 		this.yAxis.scale(this.y);
 		this.yAxisLabel.call(this.yAxis);
@@ -184,6 +186,7 @@ class TotalRewardPlot extends TooltipPlot {
 			{ x: 'Cycles', y: 'Reward', value: 'rew' }, 'rewards');
 	}
 }
+
 class AverageTrueRewardPlot extends TooltipPlot {
 	constructor(trace) {
 		super(trace, 'trew',


### PR DESCRIPTION
This patch introduces the following changes:

* Added some documentation to the experiments/analysis.ipynb notebook.
* Fixed some typos and updated the description for the reward_corruption demo.
* Introduced npm package management and ESLint, and run this linter over the codebase. From now on, we encourage the use of this linter (to set up, run `npm install` -- assuming you already have Nodejs installed).
* Added an option to turn off the live plot updates (`nolivevis`), which slow down the simulations considerably. This is particularly useful for demos that run for many (>10^3) time steps.
* Downloading the experimental results file is now optional, gated by a `download` field in the experimental parameters.